### PR TITLE
Fix path for get_groups_by_name

### DIFF
--- a/markusapi/markusapi.py
+++ b/markusapi/markusapi.py
@@ -95,7 +95,7 @@ class Markus:
         Return a dictionary mapping group names to group ids.
         """
         params = None
-        path = Markus.get_path(assignments=assignment_id, group_ids_by_name=None) + '.json'
+        path = Markus.get_path(assignments=assignment_id, groups=None, group_ids_by_name=None) + '.json'
         response = self.submit_request(params, path, 'GET')
         return Markus.decode_json_response(response)
 

--- a/markusapi/tests/test_markusapi.py
+++ b/markusapi/tests/test_markusapi.py
@@ -89,7 +89,7 @@ class TestMarkusAPICalls:
     @patch.object(Markus, 'get_path', return_value=DUMMY_RETURNS['path'])
     def test_get_groups_by_name(self, get_path, decode_json_response, submit_request, kwargs):
         dummy_markus().get_groups_by_name(**kwargs)
-        get_path.assert_called_with(assignments=kwargs['assignment_id'], group_ids_by_name=None)
+        get_path.assert_called_with(assignments=kwargs['assignment_id'], groups=None, group_ids_by_name=None)
         submit_request.assert_called_with(None, f'{get_path.return_value}.json', 'GET')
         decode_json_response.assert_called_with(submit_request.return_value)   
 


### PR DESCRIPTION
Path was missing `groups`