### PR TITLE
Rewrite everything with the requests library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 # command to install dependencies
 install:
   - pip install pytest
-  - pip install hypothesis
 # command to run tests
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-# command to install dependencies
-install:
-  - pip install pytest
 # command to run tests
 script:
-  - pytest
+  - python setup.py test

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 ##[unreleased]
 - Added new methods for adding and removing extra marks (#15)
 - Fixed bug which caused file uploads to be PUT requests by default instead of POST (#22)
+- Rewrite everything to use the requests library (#26)
 
 ##[v0.1.0]
 - this release includes functions to call all API routes for MarkUs version 1.9.0 (#10, #12, #13, #14, #18)

--- a/markusapi/markusapi.py
+++ b/markusapi/markusapi.py
@@ -14,20 +14,16 @@
 # (c) by the authors, 2008 - 2020.
 #
 
-import http.client
 import json
 import mimetypes
-from typing import Optional, List, Union, Dict, Tuple
+import requests
+from typing import Optional, List, Union, Dict
 from datetime import datetime
-from urllib.parse import urlparse, urlencode
-
-ResponseType = Tuple[int, str, bytes]
+from .response_parser import parse_response
 
 
 class Markus:
     """A class for interfacing with the MarkUs API."""
-
-    API_PATH = "/api"  # The root api path.
 
     def __init__(self, api_key: str, url: str) -> None:
         """
@@ -41,20 +37,26 @@ class Markus:
         url      -- the root domain of the MarkUs instance.
         """
         self.api_key = api_key
-        self.parsed_url = urlparse(url.strip())
-        assert self.parsed_url.scheme in ["http", "https"]
+        self.url = url
 
-    def get_all_users(self) -> List[dict]:
+    @property
+    def _auth_header(self):
+        return {"Authorization": f"MarkUsAuth {self.api_key}"}
+
+    def _url(self, tail=""):
+        return f"{self.url}/api/{tail}.json"
+
+    @parse_response("json")
+    def get_all_users(self) -> requests.Response:
         """
         Return a list of every user in the MarkUs instance.
         Each user is a dictionary object, with the following keys:
         'id', 'user_name', 'first_name', 'last_name',
         'type', 'grace_credits', 'notes_count', 'hidden'.
         """
-        params = None
-        response = self._submit_request(params, "/api/users.json", "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(self._url("users"), headers=self._auth_header)
 
+    @parse_response("json")
     def new_user(
         self,
         user_name: str,
@@ -63,7 +65,7 @@ class Markus:
         last_name: str,
         section_name: Optional[str] = None,
         grace_credits: Optional[str] = None,
-    ) -> ResponseType:
+    ) -> requests.Response:
         """
         Add a new user to the MarkUs database.
         Returns a list containing the response's status,
@@ -74,71 +76,66 @@ class Markus:
             params["section_name"] = section_name
         if grace_credits is not None:
             params["grace_credits"] = grace_credits
-        return self._submit_request(params, "/api/users", "POST")
+        return requests.post(self._url("users"), params=params, headers=self._auth_header)
 
-    def get_assignments(self) -> List[dict]:
+    @parse_response("json")
+    def get_assignments(self) -> requests.Response:
         """
         Return a list of all assignments.
         """
-        params = None
-        response = self._submit_request(params, "/api/assignments.json", "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(self._url("assignments"), headers=self._auth_header)
 
-    def get_groups(self, assignment_id: int) -> List[dict]:
+    @parse_response("json")
+    def get_groups(self, assignment_id: int) -> requests.Response:
         """
         Return a list of all groups associated with the given assignment.
         """
-        params = None
-        path = Markus._get_path(assignments=assignment_id, groups=None) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(self._url(f"assignments/{assignment_id}/groups"), headers=self._auth_header)
 
-    def get_groups_by_name(self, assignment_id: int) -> dict:
+    @parse_response("json")
+    def get_groups_by_name(self, assignment_id: int) -> requests.Response:
         """
         Return a dictionary mapping group names to group ids.
         """
-        params = None
-        path = Markus._get_path(assignments=assignment_id, groups=None, group_ids_by_name=None) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(
+            self._url(f"assignments/{assignment_id}/groups/group_ids_by_name"), headers=self._auth_header
+        )
 
-    def get_group(self, assignment_id: int, group_id: int) -> dict:
+    @parse_response("json")
+    def get_group(self, assignment_id: int, group_id: int) -> requests.Response:
         """
         Return the group info associated with the given id and assignment.
         """
-        params = None
-        path = Markus._get_path(assignments=assignment_id, groups=group_id) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(self._url(f"assignments/{assignment_id}/groups/{group_id}"), headers=self._auth_header)
 
-    def get_feedback_files(self, assignment_id: int, group_id: int) -> List[dict]:
+    @parse_response("json")
+    def get_feedback_files(self, assignment_id: int, group_id: int) -> requests.Response:
         """
         Get the feedback files info associated with the assignment and group.
         """
-        params = {}
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, feedback_files=None) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/feedback_files"), headers=self._auth_header
+        )
 
-    def get_feedback_file(self, assignment_id: int, group_id: int, feedback_file_id: int) -> str:
+    @parse_response("content")
+    def get_feedback_file(self, assignment_id: int, group_id: int, feedback_file_id: int) -> requests.Response:
         """
         Get the feedback file associated with the given id, assignment and group.
         WARNING: This will fail for non-text feedback files
         """
-        params = {}
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, feedback_files=feedback_file_id) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_text_response(response)
+        return requests.get(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/feedback_files/{feedback_file_id}"),
+            headers=self._auth_header,
+        )
 
-    def get_grades_summary(self, assignment_id: int) -> str:
+    @parse_response("text")
+    def get_grades_summary(self, assignment_id: int) -> requests.Response:
         """
         Get grades summary csv file as a string.
         """
-        params = {}
-        path = Markus._get_path(assignments=assignment_id, grades_summary=None) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_text_response(response)
+        return requests.get(self._url(f"assignments/{assignment_id}/grades_summary"), headers=self._auth_header)
 
+    @parse_response("json")
     def new_marks_spreadsheet(
         self,
         short_identifier: str,
@@ -146,8 +143,8 @@ class Markus:
         date: Optional[datetime] = None,
         is_hidden: bool = True,
         show_total: bool = True,
-        grade_entry_items: Optional[Dict[str, Union[str, bool, float]]] = None,
-    ) -> ResponseType:
+        grade_entry_items: Optional[List[Dict[str, Union[str, bool, float]]]] = None,
+    ) -> requests.Response:
         """
         Create a new marks spreadsheet
         """
@@ -159,9 +156,9 @@ class Markus:
             "show_total": show_total,
             "grade_entry_items": grade_entry_items,
         }
-        path = Markus._get_path(grade_entry_forms=None) + ".json"
-        return self._submit_request(params, path, "POST", content_type="application/json")
+        return requests.post(self._url("grade_entry_forms"), params=params, headers=self._auth_header)
 
+    @parse_response("json")
     def update_marks_spreadsheet(
         self,
         spreadsheet_id: int,
@@ -170,8 +167,8 @@ class Markus:
         date: Optional[datetime] = None,
         is_hidden: Optional[bool] = None,
         show_total: Optional[bool] = None,
-        grade_entry_items: Optional[Dict[str, Union[str, bool, float]]] = None,
-    ) -> ResponseType:
+        grade_entry_items: Optional[List[Dict[str, Union[str, bool, float]]]] = None,
+    ) -> requests.Response:
         """
         Update an existing marks spreadsheet
         """
@@ -186,34 +183,32 @@ class Markus:
         for name in list(params):
             if params[name] is None:
                 params.pop(name)
-        path = Markus._get_path(grade_entry_forms=spreadsheet_id) + ".json"
-        return self._submit_request(params, path, "PUT", content_type="application/json")
+        return requests.put(self._url(f"grade_entry_forms/{spreadsheet_id}"), params=params, headers=self._auth_header)
 
+    @parse_response("json")
     def update_marks_spreadsheets_grades(
         self, spreadsheet_id: int, user_name: str, grades_per_column: Dict[str, float]
-    ) -> ResponseType:
+    ) -> requests.Response:
         params = {"user_name": user_name, "grade_entry_items": grades_per_column}
-        path = Markus._get_path(grade_entry_forms=spreadsheet_id, update_grades=None) + ".json"
-        return self._submit_request(params, path, "PUT", content_type="application/json")
+        return requests.put(
+            self._url(f"grade_entry_forms/{spreadsheet_id}/update_grades"), json=params, headers=self._auth_header
+        )
 
-    def get_marks_spreadsheets(self) -> List[dict]:
+    @parse_response("json")
+    def get_marks_spreadsheets(self) -> requests.Response:
         """
         Get all marks spreadsheets.
         """
-        params = {}
-        path = Markus._get_path(grade_entry_forms=None) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(self._url(f"grade_entry_forms"), headers=self._auth_header)
 
-    def get_marks_spreadsheet(self, spreadsheet_id: int) -> str:
+    @parse_response("text")
+    def get_marks_spreadsheet(self, spreadsheet_id: int) -> requests.Response:
         """
         Get the marks spreadsheet associated with the given id.
         """
-        params = {}
-        path = Markus._get_path(grade_entry_forms=spreadsheet_id) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_text_response(response)
+        return requests.get(self._url(f"grade_entry_forms/{spreadsheet_id}"), headers=self._auth_header)
 
+    @parse_response("json")
     def upload_feedback_file(
         self,
         assignment_id: int,
@@ -222,7 +217,7 @@ class Markus:
         contents: Union[str, bytes],
         mime_type: Optional[str] = None,
         overwrite: bool = True,
-    ) -> ResponseType:
+    ) -> requests.Response:
         """
         Upload a feedback file to Markus.
 
@@ -234,29 +229,39 @@ class Markus:
         mime_type     -- mime type of title file, if None then the mime type will be guessed based on the file extension
         overwrite     -- whether to overwrite a feedback file with the same name that already exists in Markus
         """
-        feedback_file_id = None
+        url_content = f"assignments/{assignment_id}/groups/{group_id}/feedback_files"
         if overwrite:
             feedback_files = self.get_feedback_files(assignment_id, group_id)
             feedback_file_id = next((ff.get("id") for ff in feedback_files if ff.get("filename") == title), None)
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, feedback_files=None)
-        request_type = "POST"
-        if feedback_file_id:
-            path = "{}/{}".format(path, feedback_file_id)
-            request_type = "PUT"
+            if feedback_file_id is not None:
+                url_content += f"/{feedback_file_id}"
+            else:
+                overwrite = False
+        files = {"file_content": (title, contents)}
+        params = {"filename": title, "mime_type": mime_type or mimetypes.guess_type(title)[0]}
+        if overwrite:
+            return requests.put(self._url(url_content), files=files, params=params, headers=self._auth_header)
+        else:
+            return requests.post(self._url(url_content), files=files, params=params, headers=self._auth_header)
 
-        return self._do_file_upload(path, title, contents, mime_type, request_type)
-
+    @parse_response("json")
     def upload_test_group_results(
-        self, assignment_id: int, group_id: int, test_run_id: int, test_output: str
-    ) -> ResponseType:
+        self, assignment_id: int, group_id: int, test_run_id: int, test_output: Union[str, Dict]
+    ) -> requests.Response:
         """ Upload test results to Markus """
+        if not isinstance(test_output, str):
+            test_output = json.dumps(test_output)
         params = {"test_run_id": test_run_id, "test_output": test_output}
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, test_group_results=None)
-        return self._submit_request(params, path, "POST")
+        return requests.post(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/test_group_results"),
+            json=params,
+            headers=self._auth_header,
+        )
 
+    @parse_response("json")
     def upload_annotations(
-        self, assignment_id: int, group_id: int, annotations: dict, force_complete: bool = False
-    ) -> ResponseType:
+        self, assignment_id: int, group_id: int, annotations: List, force_complete: bool = False
+    ) -> requests.Response:
         """
         Each element of annotations must be a dictionary with the following keys:
             - filename
@@ -270,20 +275,26 @@ class Markus:
         This currently only works for plain-text file submissions.
         """
         params = {"annotations": annotations, "force_complete": force_complete}
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, add_annotations=None)
-        return self._submit_request(params, path, "POST", "application/json")
+        return requests.post(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/add_annotations"),
+            json=params,
+            headers=self._auth_header,
+        )
 
-    def get_annotations(self, assignment_id: int, group_id: Optional[int] = None) -> List[Dict]:
+    @parse_response("json")
+    def get_annotations(self, assignment_id: int, group_id: Optional[int] = None) -> requests.Response:
         """
         Return a list of dictionaries containing information for each annotation in the assignment
         with id = assignment_id. If group_id is not None, return only annotations for the given group.
         """
-        params = None
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, annotations=None) + ".json"
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/annotations"), headers=self._auth_header
+        )
 
-    def update_marks_single_group(self, criteria_mark_map: dict, assignment_id: int, group_id: int) -> ResponseType:
+    @parse_response("json")
+    def update_marks_single_group(
+        self, criteria_mark_map: dict, assignment_id: int, group_id: int
+    ) -> requests.Response:
         """
         Update the marks of a single group.
         Only the marks specified in criteria_mark_map will be changed.
@@ -299,55 +310,56 @@ class Markus:
         assignment_id     -- the assignment's id
         group_id          -- the id of the group whose marks we are updating
         """
-        params = criteria_mark_map
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, update_marks=None)
-        return self._submit_request(params, path, "PUT")
+        return requests.put(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/update_marks"),
+            json=criteria_mark_map,
+            headers=self._auth_header,
+        )
 
-    def update_marking_state(self, assignment_id: int, group_id: int, new_marking_state: str) -> ResponseType:
+    @parse_response("json")
+    def update_marking_state(self, assignment_id: int, group_id: int, new_marking_state: str) -> requests.Response:
         """ Update marking state for a single group to either 'complete' or 'incomplete' """
         params = {"marking_state": new_marking_state}
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, update_marking_state=None)
-        return self._submit_request(params, path, "PUT")
+        return requests.put(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/update_marking_state"),
+            params=params,
+            headers=self._auth_header,
+        )
 
+    @parse_response("json")
     def create_extra_marks(
-        self,
-        assignment_id: int,
-        group_id: int,
-        extra_marks: float,
-        description: str
-    ) -> ResponseType:
+        self, assignment_id: int, group_id: int, extra_marks: float, description: str
+    ) -> requests.Response:
         """
         Create new extra mark for the particular group.
         Mark specified in extra_marks will be created
         """
-        params = {
-            'extra_marks': extra_marks,
-            'description': description
-        }
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, create_extra_marks=None)
-        return self._submit_request(params, path, 'POST')
+        params = {"extra_marks": extra_marks, "description": description}
+        return requests.post(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/create_extra_marks"),
+            params=params,
+            headers=self._auth_header,
+        )
 
+    @parse_response("json")
     def remove_extra_marks(
-        self,
-        assignment_id: int,
-        group_id: int,
-        extra_marks: float,
-        description: str
-    ) -> ResponseType:
+        self, assignment_id: int, group_id: int, extra_marks: float, description: str
+    ) -> requests.Response:
         """
         Remove the extra mark for the particular group.
         Mark specified in extra_marks will be removed
         """
-        params = {
-            'extra_marks': extra_marks,
-            'description': description
-        }
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, remove_extra_marks=None)
-        return self._submit_request(params, path, 'DELETE')
+        params = {"extra_marks": extra_marks, "description": description}
+        return requests.delete(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/remove_extra_marks"),
+            params=params,
+            headers=self._auth_header,
+        )
 
+    @parse_response("content")
     def get_files_from_repo(
         self, assignment_id: int, group_id: int, filename: Optional[str] = None, collected: bool = True
-    ) -> Optional[bytes]:
+    ) -> requests.Response:
         """
         Return file content from the submission of a single group. If <filename> is specified,
         return the content of a single file, otherwise return the content of a zipfile containing
@@ -358,21 +370,27 @@ class Markus:
 
         The method returns None if there are no files to collect.
         """
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, submission_files=None) + ".json"
         params = {}
         if collected:
             params["collected"] = collected
         if filename:
             params["filename"] = filename
-        response = self._submit_request(params, path, "GET")
-        if response[0] == 200:
-            return response[2]
+        return requests.get(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/submission_files"),
+            params=params,
+            headers=self._auth_header,
+        )
 
-    def upload_folder_to_repo(self, assignment_id: int, group_id: int, folder_path: str) -> ResponseType:
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, submission_files=None, create_folders=None)
+    @parse_response("json")
+    def upload_folder_to_repo(self, assignment_id: int, group_id: int, folder_path: str) -> requests.Response:
         params = {"folder_path": folder_path}
-        return self._submit_request(params, path, "POST")
+        return requests.post(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/submission_files/create_folders"),
+            params=params,
+            headers=self._auth_header,
+        )
 
+    @parse_response("json")
     def upload_file_to_repo(
         self,
         assignment_id: int,
@@ -380,7 +398,7 @@ class Markus:
         file_path: str,
         contents: Union[str, bytes],
         mime_type: Optional[str] = None,
-    ) -> ResponseType:
+    ) -> requests.Response:
         """
         Upload a file at file_path with content contents to the assignment directory
         in the repo for group with id group_id.
@@ -390,149 +408,70 @@ class Markus:
         of the assignment with id assignment_id should be A1 and the file_path argument should be:
         'somesubdir/myfile.txt'
         """
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, submission_files=None)
+        files = {"file_content": (file_path, contents)}
+        params = {"filename": file_path, "mime_type": mime_type or mimetypes.guess_type(file_path)[0]}
+        return requests.post(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/submission_files"),
+            files=files,
+            params=params,
+            headers=self._auth_header,
+        )
 
-        return self._do_file_upload(path, file_path, contents, mime_type)
-
-    def remove_file_from_repo(self, assignment_id: int, group_id: int, file_path: str) -> ResponseType:
+    @parse_response("json")
+    def remove_file_from_repo(self, assignment_id: int, group_id: int, file_path: str) -> requests.Response:
         """
         Remove a file at file_path from the assignment directory in the repo for group with id group_id.
 
         The file_path should be a relative path from the assignment directory of a repository.
-        For example, if you want to upload a file to A1/somesubdir/myfile.txt then the short identifier
+        For example, if you want to remove a file A1/somesubdir/myfile.txt then the short identifier
         of the assignment with id assignment_id should be A1 and the file_path argument should be:
         'somesubdir/myfile.txt'
         """
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, submission_files=None, remove_file=None)
         params = {"filename": file_path}
-        return self._submit_request(params, path, "DELETE")
+        return requests.delete(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/submission_files/remove_file"),
+            params=params,
+            headers=self._auth_header,
+        )
 
-    def remove_folder_from_repo(self, assignment_id: int, group_id: int, folder_path: str) -> ResponseType:
-        path = Markus._get_path(assignments=assignment_id, groups=group_id, submission_files=None, remove_folder=None)
+    @parse_response("json")
+    def remove_folder_from_repo(self, assignment_id: int, group_id: int, folder_path: str) -> requests.Response:
+        """
+        Remove a folder at folder_path and all its contents for group with id grou;_id.
+
+        The file_path should be a relative path from the assignment directory of a repository.
+        For example, if you want to remove a folder A1/somesubdir/ then the short identifier
+        of the assignment with id assignment_id should be A1 and the folder_path argument should be:
+        'somesubdir/'
+        """
         params = {"folder_path": folder_path}
-        return self._submit_request(params, path, "DELETE")
+        return requests.delete(
+            self._url(f"assignments/{assignment_id}/groups/{group_id}/submission_files/remove_folder"),
+            params=params,
+            headers=self._auth_header,
+        )
 
-    def get_test_specs(self, assignment_id: int) -> Dict:
+    @parse_response("json")
+    def get_test_specs(self, assignment_id: int) -> requests.Response:
         """
         Get the test spec settings for an assignment with id <assignment_id>.
         """
-        path = Markus._get_path(assignments=assignment_id, test_specs=None) + ".json"
-        params = None
-        response = self._submit_request(params, path, "GET")
-        return Markus._decode_json_response(response)
+        return requests.get(self._url(f"assignments/{assignment_id}/test_specs"), headers=self._auth_header)
 
-    def update_test_specs(self, assignment_id: int, specs: Dict) -> ResponseType:
+    @parse_response("json")
+    def update_test_specs(self, assignment_id: int, specs: Dict) -> requests.Response:
         """
         Update the test spec settings for an assignment with id <assignment_id> to be <specs>.
         """
-        path = Markus._get_path(assignments=assignment_id, update_test_specs=None) + ".json"
         params = {"specs": specs}
-        return self._submit_request(params, path, "POST", content_type="application/json")
+        return requests.post(
+            self._url(f"assignments/{assignment_id}/update_test_specs"), json=params, headers=self._auth_header
+        )
 
-    def get_test_files(self, assignment_id: int) -> Optional[bytes]:
+    @parse_response("content")
+    def get_test_files(self, assignment_id: int) -> requests.Response:
         """
         Return the content of a zipfile containing the content of all files uploaded for automated testing of
         the assignment with id <assignment_id>.
         """
-        path = Markus._get_path(assignments=assignment_id, test_files=None) + ".json"
-        params = None
-        response = self._submit_request(params, path, "GET")
-        if response[0] == 200:
-            return response[2]
-
-    # Helpers
-
-    def _submit_request(
-        self,
-        params: Optional[dict],
-        path: str,
-        request_type: str,
-        content_type: str = "application/x-www-form-urlencoded",
-    ) -> ResponseType:
-        """ Return result from _do_submit_request after formatting the params and setting headers """
-        headers = {"Content-type": content_type}
-        if params is not None:
-            if content_type == "application/x-www-form-urlencoded":
-                # simple params, sent as form query string (needs url encoding of reserved and non-alphanumeric chars)
-                params = urlencode(params)
-            elif content_type == "multipart/form-data":
-                # complex params like binary files, sent as-is (assumes already-encoded data)
-                pass
-            elif content_type == "application/json":
-                # json-encoded params
-                params = json.dumps(params)
-            if not isinstance(params, str):
-                raise ValueError("If the params are not a string type object please provide a valid content_type")
-        if request_type == "GET":  # we only want this for GET requests
-            headers["Accept"] = "text/plain"
-        return self._do_submit_request(params, path, request_type, headers)
-
-    def _do_submit_request(self, params: Optional[str], path: str, request_type: str, headers: dict) -> ResponseType:
-        """
-        Perform the HTTP/HTTPS request. Return a list
-        containing the response's status, reason, and content.
-
-        Keyword arguments:
-        params       -- contains the parameters of the request
-        path         -- route to the resource we are targetting
-        request_type -- the desired HTTP method (usually 'GET' or 'POST')
-        """
-        auth_header = "MarkUsAuth {}".format(self.api_key)
-        headers["Authorization"] = auth_header
-        if self.parsed_url.scheme == "http":
-            conn = http.client.HTTPConnection(self.parsed_url.netloc)
-        elif self.parsed_url.scheme == "https":
-            conn = http.client.HTTPSConnection(self.parsed_url.netloc)
-        else:
-            raise ValueError("Panic! Neither http nor https URL.")
-        conn.request(request_type, self.parsed_url.path + path, params, headers)
-        resp = conn.getresponse()
-        lst = (resp.status, resp.reason, resp.read())
-        conn.close()
-        return lst
-
-    def _do_file_upload(
-        self,
-        path: str,
-        file_path: str,
-        contents: Union[str, bytes],
-        mime_type: Optional[str] = None,
-        request_type: str = "POST",
-    ) -> ResponseType:
-        """
-        Helper that performs requests of <request_type> to <path> that involves uploading a file named
-        <file_path> containing <content>. If <mime_type> is None, the mime type of the file will be guessed.
-        """
-        if mime_type is None:
-            mime_type = mimetypes.guess_type(file_path)[0]
-            if mime_type is None:
-                raise ValueError(
-                    "if the mime_type argument is not given you must provide a title file with a valid extension"
-                )
-
-        if isinstance(contents, str):
-            params = {"filename": file_path, "file_content": contents, "mime_type": mime_type}
-            content_type = "application/x-www-form-urlencoded"
-        else:  # binary data
-            params = {
-                "filename": file_path.encode("utf-8"),
-                "file_content": contents,
-                "mime_type": mime_type.encode("utf-8"),
-            }
-            content_type = "multipart/form-data"
-        return self._submit_request(params, path, request_type, content_type)
-
-    @staticmethod
-    def _get_path(**kwargs: Optional[int]) -> str:
-        path = "/".join([str(v) for vals in kwargs.items() for v in vals if v is not None])
-        return f"{Markus.API_PATH}/{path}"
-
-    @staticmethod
-    def _decode_text_response(resp: ResponseType) -> str:
-        """Converts response from _submit_request into a utf-8 string."""
-        return resp[2].decode("utf-8")
-
-    @staticmethod
-    def _decode_json_response(resp: ResponseType) -> Union[List[Dict], Dict]:
-        """Converts response from _submit_request into python dict."""
-        return json.loads(Markus._decode_text_response(resp))
+        return requests.get(self._url(f"assignments/{assignment_id}/test_files"), headers=self._auth_header)

--- a/markusapi/response_parser.py
+++ b/markusapi/response_parser.py
@@ -1,0 +1,45 @@
+from functools import wraps
+from typing import List, Union, Dict, Callable
+
+
+def parse_response(expected: str) -> Callable:
+    """
+    Decorator for a function that returns a requests.Response object.
+    This decorator parses that response depending on the value of <expected>.
+
+    If the response indicates the request failed (status >= 400) a dictionary
+    containing the response status and message will be returned. Otherwise,
+    the content will be parsed and a dictionary or list will be returned if
+    expected == 'json', a string will be returned if expected == 'text' and
+    a binary string will be returned if expected == 'content'.
+
+    This also updates the return annotation for the wrapped function according
+    to the expected return value type.
+    """
+
+    def _parser(f):
+        @wraps(f)
+        def _f(*args, **kwargs):
+            response = f(*args, **kwargs)
+            if not response.ok or expected == "json":
+                return response.json()
+            if expected == "content":
+                return response.content
+            if expected == "text":
+                return response.text
+            return response.json()
+
+        f.__annotations__["return"] = _get_expected_return(expected)
+        return _f
+
+    return _parser
+
+
+def _get_expected_return(expected: str) -> type:
+    if expected == "json":
+        return Union[Dict[str, str], List[Dict[str, str]]]
+    elif expected == "content":
+        return Union[Dict[str, str], bytes]
+    elif expected == "text":
+        return Union[Dict[str, str], bytes]
+    return Dict[str, str]

--- a/markusapi/tests/test_markusapi.py
+++ b/markusapi/tests/test_markusapi.py
@@ -57,10 +57,12 @@ class AbstractTestClass(abc.ABC):
         assert basic_call == self.response_format
 
     def test_called_with_correct_athorization(self, response_mock, basic_call):
-        assert response_mock.call_args.kwargs["headers"]["Authorization"] == f"MarkUsAuth {FAKE_API_KEY}"
+        _, kwargs = response_mock.call_args
+        assert kwargs["headers"]["Authorization"] == f"MarkUsAuth {FAKE_API_KEY}"
 
     def test_called_with_correct_url(self, response_mock, basic_call):
-        assert response_mock.call_args.args[0] == f"{FAKE_URL}/api/{self.url}.json"
+        args, _ = response_mock.call_args
+        assert args[0] == f"{FAKE_URL}/api/{self.url}.json"
 
 
 class TestGetAllUsers(AbstractTestClass):
@@ -87,7 +89,8 @@ class TestNewUser(AbstractTestClass):
     def test_called_with_basic_params(self, api, response_mock):
         api.new_user("test", "Student", "first", "last")
         params = {"user_name": "test", "type": "Student", "first_name": "first", "last_name": "last"}
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_called_with_section(self, api, response_mock):
         api.new_user("test", "Student", "first", "last", section_name="section")
@@ -98,7 +101,8 @@ class TestNewUser(AbstractTestClass):
             "last_name": "last",
             "section_name": "section",
         }
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_called_with_grace_credits(self, api, response_mock):
         api.new_user("test", "Student", "first", "last", grace_credits="3")
@@ -109,7 +113,8 @@ class TestNewUser(AbstractTestClass):
             "last_name": "last",
             "grace_credits": "3",
         }
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
 
 class TestGetAssignments(AbstractTestClass):
@@ -210,7 +215,8 @@ class TestNewMarksSpreadsheet(AbstractTestClass):
             "show_total": True,
             "grade_entry_items": None,
         }
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_called_with_is_hidden(self, api, response_mock):
         now = datetime.datetime.now()
@@ -223,7 +229,8 @@ class TestNewMarksSpreadsheet(AbstractTestClass):
             "show_total": True,
             "grade_entry_items": None,
         }
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_called_with_is_show_total(self, api, response_mock):
         now = datetime.datetime.now()
@@ -236,7 +243,8 @@ class TestNewMarksSpreadsheet(AbstractTestClass):
             "show_total": False,
             "grade_entry_items": None,
         }
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_called_with_is_show_grade_entry_items(self, api, response_mock):
         now = datetime.datetime.now()
@@ -250,7 +258,8 @@ class TestNewMarksSpreadsheet(AbstractTestClass):
             "show_total": True,
             "grade_entry_items": ge_items,
         }
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
 
 class TestUpdateMarksSpreadsheet(AbstractTestClass):
@@ -267,19 +276,22 @@ class TestUpdateMarksSpreadsheet(AbstractTestClass):
         now = datetime.datetime.now()
         api.update_marks_spreadsheet(1, "test", "description", now)
         params = {"short_identifier": "test", "description": "description", "date": now}
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_called_with_is_hidden(self, api, response_mock):
         now = datetime.datetime.now()
         api.update_marks_spreadsheet(1, "test", "description", now, is_hidden=False)
         params = {"short_identifier": "test", "description": "description", "date": now, "is_hidden": False}
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_called_with_is_show_total(self, api, response_mock):
         now = datetime.datetime.now()
         api.update_marks_spreadsheet(1, "test", "description", now, show_total=False)
         params = {"short_identifier": "test", "description": "description", "date": now, "show_total": False}
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_called_with_is_show_grade_entry_items(self, api, response_mock):
         now = datetime.datetime.now()
@@ -291,7 +303,8 @@ class TestUpdateMarksSpreadsheet(AbstractTestClass):
             "date": now,
             "grade_entry_items": ge_items,
         }
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
 
 class TestUpdateMarksSpreadsheetGrades(AbstractTestClass):
@@ -307,7 +320,8 @@ class TestUpdateMarksSpreadsheetGrades(AbstractTestClass):
     def test_called_with_basic_params(self, api, response_mock):
         api.update_marks_spreadsheets_grades(1, "some_user", {"some_column": 2})
         params = {"user_name": "some_user", "grade_entry_items": {"some_column": 2}}
-        assert response_mock.call_args.kwargs["json"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["json"] == params
 
 
 class TestGetMarksSpreadsheets(AbstractTestClass):
@@ -346,19 +360,22 @@ class TestUploadFeedbackFileReplace(AbstractTestClass):
     def test_discovers_mime_type(self, api, response_mock):
         api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "test.txt"}])
         api.upload_feedback_file(1, 1, "test.txt", "feedback info")
-        assert response_mock.call_args.kwargs["params"]["mime_type"] == "text/plain"
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"]["mime_type"] == "text/plain"
 
     def test_called_with_mime_type(self, api, response_mock):
         api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "test.txt"}])
         api.upload_feedback_file(1, 1, "test.txt", "feedback info", mime_type="application/octet-stream")
         params = {"filename": "test.txt", "mime_type": "application/octet-stream"}
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_sends_file_data(self, api, response_mock):
         api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "test.txt"}])
         api.upload_feedback_file(1, 1, "test.txt", "feedback info")
         files = {"file_content": ("test.txt", "feedback info")}
-        assert response_mock.call_args.kwargs["files"] == files
+        _, kwargs = response_mock.call_args
+        assert kwargs["files"] == files
 
 
 class TestUploadFeedbackFileNew(AbstractTestClass):
@@ -394,7 +411,8 @@ class TestUploadTestGroupResultsJsonString(AbstractTestClass):
     def test_called_wth_basic_args(self, api, response_mock):
         api.upload_test_group_results(1, 1, 1, '{"data": []}')
         params = {"test_run_id": 1, "test_output": '{"data": []}'}
-        assert response_mock.call_args.kwargs["json"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["json"] == params
 
 
 class TestUploadTestGroupResultsDict(AbstractTestClass):
@@ -409,7 +427,8 @@ class TestUploadTestGroupResultsDict(AbstractTestClass):
 
     def test_dict_changed_to_json_string(self, api, response_mock):
         api.upload_test_group_results(1, 1, 1, {"data": []})
-        assert response_mock.call_args.kwargs["json"]["test_output"] == '{"data": []}'
+        _, kwargs = response_mock.call_args
+        assert kwargs["json"]["test_output"] == '{"data": []}'
 
 
 class TestUploadAnnotations(AbstractTestClass):
@@ -436,12 +455,14 @@ class TestUploadAnnotations(AbstractTestClass):
     def test_called_with_basic_params(self, api, response_mock):
         api.upload_annotations(1, 1, self.annotations)
         params = {"annotations": self.annotations, "force_complete": False}
-        assert response_mock.call_args.kwargs["json"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["json"] == params
 
     def test_called_with_force_complete(self, api, response_mock):
         api.upload_annotations(1, 1, self.annotations, True)
         params = {"annotations": self.annotations, "force_complete": True}
-        assert response_mock.call_args.kwargs["json"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["json"] == params
 
 
 class TestGetAnnotations(AbstractTestClass):
@@ -467,7 +488,8 @@ class TestUpdateMarksSingleGroup(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.update_marks_single_group({"criteria_a": 10}, 1, 1)
-        assert response_mock.call_args.kwargs["json"] == {"criteria_a": 10}
+        _, kwargs = response_mock.call_args
+        assert kwargs["json"] == {"criteria_a": 10}
 
 
 class TestUpdateMarkingState(AbstractTestClass):
@@ -482,7 +504,8 @@ class TestUpdateMarkingState(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.update_marking_state(1, 1, "collected")
-        assert response_mock.call_args.kwargs["params"] == {"marking_state": "collected"}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {"marking_state": "collected"}
 
 
 class TestCreateExtraMarks(AbstractTestClass):
@@ -497,7 +520,8 @@ class TestCreateExtraMarks(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.create_extra_marks(1, 1, 10, "a bonus!")
-        assert response_mock.call_args.kwargs["params"] == {"extra_marks": 10, "description": "a bonus!"}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {"extra_marks": 10, "description": "a bonus!"}
 
 
 class TestRemoveExtraMarks(AbstractTestClass):
@@ -512,7 +536,8 @@ class TestRemoveExtraMarks(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.remove_extra_marks(1, 1, 10, "a bonus!")
-        assert response_mock.call_args.kwargs["params"] == {"extra_marks": 10, "description": "a bonus!"}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {"extra_marks": 10, "description": "a bonus!"}
 
 
 class TestGetFilesFromRepo(AbstractTestClass):
@@ -527,15 +552,18 @@ class TestGetFilesFromRepo(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.get_files_from_repo(1, 1)
-        assert response_mock.call_args.kwargs["params"] == {"collected": True}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {"collected": True}
 
     def test_called_with_collected(self, api, response_mock):
         api.get_files_from_repo(1, 1, collected=False)
-        assert response_mock.call_args.kwargs["params"] == {}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {}
 
     def test_called_with_filename(self, api, response_mock):
         api.get_files_from_repo(1, 1, filename="test.txt")
-        assert response_mock.call_args.kwargs["params"] == {"collected": True, "filename": "test.txt"}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {"collected": True, "filename": "test.txt"}
 
 
 class TestUploadFolderToRepo(AbstractTestClass):
@@ -550,7 +578,8 @@ class TestUploadFolderToRepo(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.upload_folder_to_repo(1, 1, "subdir")
-        assert response_mock.call_args.kwargs["params"] == {"folder_path": "subdir"}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {"folder_path": "subdir"}
 
 
 class TestUploadFileToRepo(AbstractTestClass):
@@ -565,17 +594,20 @@ class TestUploadFileToRepo(AbstractTestClass):
 
     def test_discovers_mime_type(self, api, response_mock):
         api.upload_file_to_repo(1, 1, "test.txt", "some content")
-        assert response_mock.call_args.kwargs["params"]["mime_type"] == "text/plain"
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"]["mime_type"] == "text/plain"
 
     def test_called_with_mime_type(self, api, response_mock):
         api.upload_file_to_repo(1, 1, "test.txt", "feedback info", mime_type="application/octet-stream")
         params = {"filename": "test.txt", "mime_type": "application/octet-stream"}
-        assert response_mock.call_args.kwargs["params"] == params
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == params
 
     def test_sends_file_data(self, api, response_mock):
         api.upload_file_to_repo(1, 1, "test.txt", "some content")
         files = {"file_content": ("test.txt", "some content")}
-        assert response_mock.call_args.kwargs["files"] == files
+        _, kwargs = response_mock.call_args
+        assert kwargs["files"] == files
 
 
 class TestRemoveFileFromRepo(AbstractTestClass):
@@ -590,7 +622,8 @@ class TestRemoveFileFromRepo(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.remove_file_from_repo(1, 1, "test.txt")
-        assert response_mock.call_args.kwargs["params"] == {"filename": "test.txt"}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {"filename": "test.txt"}
 
 
 class TestRemoveFolderFromRepo(AbstractTestClass):
@@ -605,7 +638,8 @@ class TestRemoveFolderFromRepo(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.remove_folder_from_repo(1, 1, "subdir")
-        assert response_mock.call_args.kwargs["params"] == {"folder_path": "subdir"}
+        _, kwargs = response_mock.call_args
+        assert kwargs["params"] == {"folder_path": "subdir"}
 
 
 class TestGetTestSpecs(AbstractTestClass):
@@ -632,7 +666,8 @@ class TestUpdateTestSpecs(AbstractTestClass):
     def test_called_with_basic_params(self, api, response_mock):
         specs = {"some": ["fake", "data"]}
         api.update_test_specs(1, specs)
-        assert response_mock.call_args.kwargs["json"] == {"specs": specs}
+        _, kwargs = response_mock.call_args
+        assert kwargs["json"] == {"specs": specs}
 
 
 class TestGetTestFiles(AbstractTestClass):

--- a/markusapi/tests/test_markusapi.py
+++ b/markusapi/tests/test_markusapi.py
@@ -4,8 +4,8 @@ import markusapi
 import datetime
 from unittest.mock import patch, PropertyMock, Mock
 
-FAKE_API_KEY = 'fake_api_key'
-FAKE_URL = 'http://example.com'
+FAKE_API_KEY = "fake_api_key"
+FAKE_URL = "http://example.com"
 
 
 @pytest.fixture
@@ -14,15 +14,14 @@ def api():
 
 
 class AbstractTestClass(abc.ABC):
-
     @classmethod
     @pytest.fixture
     def response_mock(cls):
-        with patch(f'requests.{cls.request_verb}') as mock:
+        with patch(f"requests.{cls.request_verb}") as mock:
             type(mock.return_value).ok = PropertyMock(return_value=True)
-            mock.return_value.content = 'content'
-            mock.return_value.text = 'text'
-            mock.return_value.json.return_value = 'json'
+            mock.return_value.content = "content"
+            mock.return_value.text = "text"
+            mock.return_value.json.return_value = "json"
             yield mock
 
     @classmethod
@@ -52,22 +51,22 @@ class AbstractTestClass(abc.ABC):
         pass
 
     def test_json_response_data_on_failure(self, bad_response_mock, basic_call):
-        assert basic_call == 'json'
+        assert basic_call == "json"
 
     def test_correct_response_data_on_success(self, response_mock, basic_call):
         assert basic_call == self.response_format
 
     def test_called_with_correct_athorization(self, response_mock, basic_call):
-        assert response_mock.call_args.kwargs['headers']['Authorization'] == f'MarkUsAuth {FAKE_API_KEY}'
+        assert response_mock.call_args.kwargs["headers"]["Authorization"] == f"MarkUsAuth {FAKE_API_KEY}"
 
     def test_called_with_correct_url(self, response_mock, basic_call):
-        assert response_mock.call_args.args[0] == f'{FAKE_URL}/api/{self.url}.json'
+        assert response_mock.call_args.args[0] == f"{FAKE_URL}/api/{self.url}.json"
 
 
 class TestGetAllUsers(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'users'
+    request_verb = "get"
+    response_format = "json"
+    url = "users"
 
     @staticmethod
     @pytest.fixture
@@ -76,35 +75,47 @@ class TestGetAllUsers(AbstractTestClass):
 
 
 class TestNewUser(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'users'
+    request_verb = "post"
+    response_format = "json"
+    url = "users"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        return api.new_user('test', 'Student', 'first', 'last', 'section', '3')
+        return api.new_user("test", "Student", "first", "last", "section", "3")
 
     def test_called_with_basic_params(self, api, response_mock):
-        api.new_user('test', 'Student', 'first', 'last')
-        params = {"user_name": 'test', "type": 'Student', "first_name": 'first', "last_name": 'last'}
-        assert response_mock.call_args.kwargs['params'] == params
+        api.new_user("test", "Student", "first", "last")
+        params = {"user_name": "test", "type": "Student", "first_name": "first", "last_name": "last"}
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_called_with_section(self, api, response_mock):
-        api.new_user('test', 'Student', 'first', 'last', section_name='section')
-        params = {"user_name": 'test', "type": 'Student', "first_name": 'first', "last_name": 'last', 'section_name': 'section'}
-        assert response_mock.call_args.kwargs['params'] == params
+        api.new_user("test", "Student", "first", "last", section_name="section")
+        params = {
+            "user_name": "test",
+            "type": "Student",
+            "first_name": "first",
+            "last_name": "last",
+            "section_name": "section",
+        }
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_called_with_grace_credits(self, api, response_mock):
-        api.new_user('test', 'Student', 'first', 'last', grace_credits='3')
-        params = {"user_name": 'test', "type": 'Student', "first_name": 'first', "last_name": 'last', 'grace_credits': '3'}
-        assert response_mock.call_args.kwargs['params'] == params
+        api.new_user("test", "Student", "first", "last", grace_credits="3")
+        params = {
+            "user_name": "test",
+            "type": "Student",
+            "first_name": "first",
+            "last_name": "last",
+            "grace_credits": "3",
+        }
+        assert response_mock.call_args.kwargs["params"] == params
 
 
 class TestGetAssignments(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'assignments'
+    request_verb = "get"
+    response_format = "json"
+    url = "assignments"
 
     @staticmethod
     @pytest.fixture
@@ -113,9 +124,9 @@ class TestGetAssignments(AbstractTestClass):
 
 
 class TestGetGroups(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'assignments/1/groups'
+    request_verb = "get"
+    response_format = "json"
+    url = "assignments/1/groups"
 
     @staticmethod
     @pytest.fixture
@@ -124,9 +135,9 @@ class TestGetGroups(AbstractTestClass):
 
 
 class TestGetGroupsByName(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'assignments/1/groups/group_ids_by_name'
+    request_verb = "get"
+    response_format = "json"
+    url = "assignments/1/groups/group_ids_by_name"
 
     @staticmethod
     @pytest.fixture
@@ -135,9 +146,9 @@ class TestGetGroupsByName(AbstractTestClass):
 
 
 class TestGetGroup(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'assignments/1/groups/1'
+    request_verb = "get"
+    response_format = "json"
+    url = "assignments/1/groups/1"
 
     @staticmethod
     @pytest.fixture
@@ -146,9 +157,9 @@ class TestGetGroup(AbstractTestClass):
 
 
 class TestGetFeedbackFiles(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/feedback_files'
+    request_verb = "get"
+    response_format = "json"
+    url = "assignments/1/groups/1/feedback_files"
 
     @staticmethod
     @pytest.fixture
@@ -157,9 +168,9 @@ class TestGetFeedbackFiles(AbstractTestClass):
 
 
 class TestGetFeedbackFile(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'content'
-    url = 'assignments/1/groups/1/feedback_files/1'
+    request_verb = "get"
+    response_format = "content"
+    url = "assignments/1/groups/1/feedback_files/1"
 
     @staticmethod
     @pytest.fixture
@@ -168,9 +179,9 @@ class TestGetFeedbackFile(AbstractTestClass):
 
 
 class TestGetGradesSummary(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'text'
-    url = 'assignments/1/grades_summary'
+    request_verb = "get"
+    response_format = "text"
+    url = "assignments/1/grades_summary"
 
     @staticmethod
     @pytest.fixture
@@ -179,147 +190,130 @@ class TestGetGradesSummary(AbstractTestClass):
 
 
 class TestNewMarksSpreadsheet(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'grade_entry_forms'
+    request_verb = "post"
+    response_format = "json"
+    url = "grade_entry_forms"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.new_marks_spreadsheet('test', 'description', datetime.datetime.now())
+        yield api.new_marks_spreadsheet("test", "description", datetime.datetime.now())
 
     def test_called_with_basic_params(self, api, response_mock):
         now = datetime.datetime.now()
-        api.new_marks_spreadsheet('test', 'description', now)
+        api.new_marks_spreadsheet("test", "description", now)
         params = {
-            "short_identifier": 'test',
-            "description": 'description',
+            "short_identifier": "test",
+            "description": "description",
             "date": now,
             "is_hidden": True,
             "show_total": True,
             "grade_entry_items": None,
         }
-        assert response_mock.call_args.kwargs['params'] == params
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_called_with_is_hidden(self, api, response_mock):
         now = datetime.datetime.now()
-        api.new_marks_spreadsheet('test', 'description', now, is_hidden=False)
+        api.new_marks_spreadsheet("test", "description", now, is_hidden=False)
         params = {
-            "short_identifier": 'test',
-            "description": 'description',
+            "short_identifier": "test",
+            "description": "description",
             "date": now,
             "is_hidden": False,
             "show_total": True,
             "grade_entry_items": None,
         }
-        assert response_mock.call_args.kwargs['params'] == params
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_called_with_is_show_total(self, api, response_mock):
         now = datetime.datetime.now()
-        api.new_marks_spreadsheet('test', 'description', now, show_total=False)
+        api.new_marks_spreadsheet("test", "description", now, show_total=False)
         params = {
-            "short_identifier": 'test',
-            "description": 'description',
+            "short_identifier": "test",
+            "description": "description",
             "date": now,
             "is_hidden": True,
             "show_total": False,
             "grade_entry_items": None,
         }
-        assert response_mock.call_args.kwargs['params'] == params
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_called_with_is_show_grade_entry_items(self, api, response_mock):
         now = datetime.datetime.now()
-        ge_items = [{'name': 'a', 'out_of': 4}]
-        api.new_marks_spreadsheet('test', 'description', now, grade_entry_items=ge_items)
+        ge_items = [{"name": "a", "out_of": 4}]
+        api.new_marks_spreadsheet("test", "description", now, grade_entry_items=ge_items)
         params = {
-            "short_identifier": 'test',
-            "description": 'description',
+            "short_identifier": "test",
+            "description": "description",
             "date": now,
             "is_hidden": True,
             "show_total": True,
             "grade_entry_items": ge_items,
         }
-        assert response_mock.call_args.kwargs['params'] == params
+        assert response_mock.call_args.kwargs["params"] == params
 
 
 class TestUpdateMarksSpreadsheet(AbstractTestClass):
-    request_verb = 'put'
-    response_format = 'json'
-    url = 'grade_entry_forms/1'
+    request_verb = "put"
+    response_format = "json"
+    url = "grade_entry_forms/1"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.update_marks_spreadsheet(1, 'test', 'description', datetime.datetime.now())
+        yield api.update_marks_spreadsheet(1, "test", "description", datetime.datetime.now())
 
     def test_called_with_basic_params(self, api, response_mock):
         now = datetime.datetime.now()
-        api.update_marks_spreadsheet(1, 'test', 'description', now)
-        params = {
-            "short_identifier": 'test',
-            "description": 'description',
-            "date": now
-        }
-        assert response_mock.call_args.kwargs['params'] == params
+        api.update_marks_spreadsheet(1, "test", "description", now)
+        params = {"short_identifier": "test", "description": "description", "date": now}
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_called_with_is_hidden(self, api, response_mock):
         now = datetime.datetime.now()
-        api.update_marks_spreadsheet(1, 'test', 'description', now, is_hidden=False)
-        params = {
-            "short_identifier": 'test',
-            "description": 'description',
-            "date": now,
-            "is_hidden": False
-        }
-        assert response_mock.call_args.kwargs['params'] == params
+        api.update_marks_spreadsheet(1, "test", "description", now, is_hidden=False)
+        params = {"short_identifier": "test", "description": "description", "date": now, "is_hidden": False}
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_called_with_is_show_total(self, api, response_mock):
         now = datetime.datetime.now()
-        api.update_marks_spreadsheet(1, 'test', 'description', now, show_total=False)
-        params = {
-            "short_identifier": 'test',
-            "description": 'description',
-            "date": now,
-            "show_total": False
-        }
-        assert response_mock.call_args.kwargs['params'] == params
+        api.update_marks_spreadsheet(1, "test", "description", now, show_total=False)
+        params = {"short_identifier": "test", "description": "description", "date": now, "show_total": False}
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_called_with_is_show_grade_entry_items(self, api, response_mock):
         now = datetime.datetime.now()
-        ge_items = [{'name': 'a', 'out_of': 4}]
-        api.update_marks_spreadsheet(1, 'test', 'description', now, grade_entry_items=ge_items)
+        ge_items = [{"name": "a", "out_of": 4}]
+        api.update_marks_spreadsheet(1, "test", "description", now, grade_entry_items=ge_items)
         params = {
-            "short_identifier": 'test',
-            "description": 'description',
+            "short_identifier": "test",
+            "description": "description",
             "date": now,
             "grade_entry_items": ge_items,
         }
-        assert response_mock.call_args.kwargs['params'] == params
+        assert response_mock.call_args.kwargs["params"] == params
 
 
 class TestUpdateMarksSpreadsheetGrades(AbstractTestClass):
-    request_verb = 'put'
-    response_format = 'json'
-    url = 'grade_entry_forms/1/update_grades'
+    request_verb = "put"
+    response_format = "json"
+    url = "grade_entry_forms/1/update_grades"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.update_marks_spreadsheets_grades(1, 'some_user', {'some_column': 2})
+        yield api.update_marks_spreadsheets_grades(1, "some_user", {"some_column": 2})
 
     def test_called_with_basic_params(self, api, response_mock):
-        api.update_marks_spreadsheets_grades(1, 'some_user', {'some_column': 2})
-        params = {
-            "user_name": 'some_user',
-            "grade_entry_items": {'some_column': 2}
-        }
-        assert response_mock.call_args.kwargs['json'] == params
+        api.update_marks_spreadsheets_grades(1, "some_user", {"some_column": 2})
+        params = {"user_name": "some_user", "grade_entry_items": {"some_column": 2}}
+        assert response_mock.call_args.kwargs["json"] == params
 
 
 class TestGetMarksSpreadsheets(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'grade_entry_forms'
+    request_verb = "get"
+    response_format = "json"
+    url = "grade_entry_forms"
 
     @staticmethod
     @pytest.fixture
@@ -328,9 +322,9 @@ class TestGetMarksSpreadsheets(AbstractTestClass):
 
 
 class TestGetMarksSpreadsheet(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'text'
-    url = 'grade_entry_forms/1'
+    request_verb = "get"
+    response_format = "text"
+    url = "grade_entry_forms/1"
 
     @staticmethod
     @pytest.fixture
@@ -339,58 +333,58 @@ class TestGetMarksSpreadsheet(AbstractTestClass):
 
 
 class TestUploadFeedbackFileReplace(AbstractTestClass):
-    request_verb = 'put'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/feedback_files/1'
+    request_verb = "put"
+    response_format = "json"
+    url = "assignments/1/groups/1/feedback_files/1"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        api.get_feedback_files = Mock(return_value=[{'id': 1, 'filename': 'test.txt'}])
-        yield api.upload_feedback_file(1, 1, 'test.txt', 'feedback info')
+        api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "test.txt"}])
+        yield api.upload_feedback_file(1, 1, "test.txt", "feedback info")
 
     def test_discovers_mime_type(self, api, response_mock):
-        api.get_feedback_files = Mock(return_value=[{'id': 1, 'filename': 'test.txt'}])
-        api.upload_feedback_file(1, 1, 'test.txt', 'feedback info')
-        assert response_mock.call_args.kwargs['params']["mime_type"] == 'text/plain'
+        api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "test.txt"}])
+        api.upload_feedback_file(1, 1, "test.txt", "feedback info")
+        assert response_mock.call_args.kwargs["params"]["mime_type"] == "text/plain"
 
     def test_called_with_mime_type(self, api, response_mock):
-        api.get_feedback_files = Mock(return_value=[{'id': 1, 'filename': 'test.txt'}])
-        api.upload_feedback_file(1, 1, 'test.txt', 'feedback info', mime_type='application/octet-stream')
-        params = {"filename": 'test.txt', "mime_type": 'application/octet-stream'}
-        assert response_mock.call_args.kwargs['params'] == params
+        api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "test.txt"}])
+        api.upload_feedback_file(1, 1, "test.txt", "feedback info", mime_type="application/octet-stream")
+        params = {"filename": "test.txt", "mime_type": "application/octet-stream"}
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_sends_file_data(self, api, response_mock):
-        api.get_feedback_files = Mock(return_value=[{'id': 1, 'filename': 'test.txt'}])
-        api.upload_feedback_file(1, 1, 'test.txt', 'feedback info')
-        files = {"file_content": ('test.txt', 'feedback info')}
-        assert response_mock.call_args.kwargs['files'] == files
+        api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "test.txt"}])
+        api.upload_feedback_file(1, 1, "test.txt", "feedback info")
+        files = {"file_content": ("test.txt", "feedback info")}
+        assert response_mock.call_args.kwargs["files"] == files
 
 
 class TestUploadFeedbackFileNew(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/feedback_files'
+    request_verb = "post"
+    response_format = "json"
+    url = "assignments/1/groups/1/feedback_files"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        api.get_feedback_files = Mock(return_value=[{'id': 1, 'filename': 'other.txt'}])
-        yield api.upload_feedback_file(1, 1, 'test.txt', 'feedback info')
+        api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "other.txt"}])
+        yield api.upload_feedback_file(1, 1, "test.txt", "feedback info")
 
 
 class TestUploadFeedbackFileNoOverwrite(TestUploadFeedbackFileNew):
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        api.get_feedback_files = Mock(return_value=[{'id': 1, 'filename': 'test.txt'}])
-        yield api.upload_feedback_file(1, 1, 'test.txt', 'feedback info', overwrite=False)
+        api.get_feedback_files = Mock(return_value=[{"id": 1, "filename": "test.txt"}])
+        yield api.upload_feedback_file(1, 1, "test.txt", "feedback info", overwrite=False)
 
 
 class TestUploadTestGroupResultsJsonString(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/test_group_results'
+    request_verb = "post"
+    response_format = "json"
+    url = "assignments/1/groups/1/test_group_results"
 
     @staticmethod
     @pytest.fixture
@@ -400,13 +394,13 @@ class TestUploadTestGroupResultsJsonString(AbstractTestClass):
     def test_called_wth_basic_args(self, api, response_mock):
         api.upload_test_group_results(1, 1, 1, '{"data": []}')
         params = {"test_run_id": 1, "test_output": '{"data": []}'}
-        assert response_mock.call_args.kwargs['json'] == params
+        assert response_mock.call_args.kwargs["json"] == params
 
 
 class TestUploadTestGroupResultsDict(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/test_group_results'
+    request_verb = "post"
+    response_format = "json"
+    url = "assignments/1/groups/1/test_group_results"
 
     @staticmethod
     @pytest.fixture
@@ -415,22 +409,24 @@ class TestUploadTestGroupResultsDict(AbstractTestClass):
 
     def test_dict_changed_to_json_string(self, api, response_mock):
         api.upload_test_group_results(1, 1, 1, {"data": []})
-        assert response_mock.call_args.kwargs['json']["test_output"] == '{"data": []}'
+        assert response_mock.call_args.kwargs["json"]["test_output"] == '{"data": []}'
 
 
 class TestUploadAnnotations(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/add_annotations'
-    annotations = [{
-        "filename": 'test.txt',
-        "annotation_category_name": "category",
-        "content": "something",
-        "line_start": 1,
-        "line_end": 2,
-        "column_start": 3,
-        "column_end": 10,
-    }]
+    request_verb = "post"
+    response_format = "json"
+    url = "assignments/1/groups/1/add_annotations"
+    annotations = [
+        {
+            "filename": "test.txt",
+            "annotation_category_name": "category",
+            "content": "something",
+            "line_start": 1,
+            "line_end": 2,
+            "column_start": 3,
+            "column_end": 10,
+        }
+    ]
 
     @classmethod
     @pytest.fixture
@@ -440,18 +436,18 @@ class TestUploadAnnotations(AbstractTestClass):
     def test_called_with_basic_params(self, api, response_mock):
         api.upload_annotations(1, 1, self.annotations)
         params = {"annotations": self.annotations, "force_complete": False}
-        assert response_mock.call_args.kwargs['json'] == params
+        assert response_mock.call_args.kwargs["json"] == params
 
     def test_called_with_force_complete(self, api, response_mock):
         api.upload_annotations(1, 1, self.annotations, True)
         params = {"annotations": self.annotations, "force_complete": True}
-        assert response_mock.call_args.kwargs['json'] == params
+        assert response_mock.call_args.kwargs["json"] == params
 
 
 class TestGetAnnotations(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/annotations'
+    request_verb = "get"
+    response_format = "json"
+    url = "assignments/1/groups/1/annotations"
 
     @staticmethod
     @pytest.fixture
@@ -460,9 +456,9 @@ class TestGetAnnotations(AbstractTestClass):
 
 
 class TestUpdateMarksSingleGroup(AbstractTestClass):
-    request_verb = 'put'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/update_marks'
+    request_verb = "put"
+    response_format = "json"
+    url = "assignments/1/groups/1/update_marks"
 
     @staticmethod
     @pytest.fixture
@@ -471,58 +467,58 @@ class TestUpdateMarksSingleGroup(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.update_marks_single_group({"criteria_a": 10}, 1, 1)
-        assert response_mock.call_args.kwargs['json'] == {"criteria_a": 10}
+        assert response_mock.call_args.kwargs["json"] == {"criteria_a": 10}
 
 
 class TestUpdateMarkingState(AbstractTestClass):
-    request_verb = 'put'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/update_marking_state'
+    request_verb = "put"
+    response_format = "json"
+    url = "assignments/1/groups/1/update_marking_state"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.update_marking_state(1, 1, 'collected')
+        yield api.update_marking_state(1, 1, "collected")
 
     def test_called_with_basic_params(self, api, response_mock):
-        api.update_marking_state(1, 1, 'collected')
-        assert response_mock.call_args.kwargs['params'] == {"marking_state": 'collected'}
+        api.update_marking_state(1, 1, "collected")
+        assert response_mock.call_args.kwargs["params"] == {"marking_state": "collected"}
 
 
 class TestCreateExtraMarks(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/create_extra_marks'
+    request_verb = "post"
+    response_format = "json"
+    url = "assignments/1/groups/1/create_extra_marks"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.create_extra_marks(1, 1, 10, 'a bonus!')
+        yield api.create_extra_marks(1, 1, 10, "a bonus!")
 
     def test_called_with_basic_params(self, api, response_mock):
-        api.create_extra_marks(1, 1, 10, 'a bonus!')
-        assert response_mock.call_args.kwargs['params'] == {"extra_marks": 10, "description": 'a bonus!'}
+        api.create_extra_marks(1, 1, 10, "a bonus!")
+        assert response_mock.call_args.kwargs["params"] == {"extra_marks": 10, "description": "a bonus!"}
 
 
 class TestRemoveExtraMarks(AbstractTestClass):
-    request_verb = 'delete'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/remove_extra_marks'
+    request_verb = "delete"
+    response_format = "json"
+    url = "assignments/1/groups/1/remove_extra_marks"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.remove_extra_marks(1, 1, 10, 'a bonus!')
+        yield api.remove_extra_marks(1, 1, 10, "a bonus!")
 
     def test_called_with_basic_params(self, api, response_mock):
-        api.remove_extra_marks(1, 1, 10, 'a bonus!')
-        assert response_mock.call_args.kwargs['params'] == {"extra_marks": 10, "description": 'a bonus!'}
+        api.remove_extra_marks(1, 1, 10, "a bonus!")
+        assert response_mock.call_args.kwargs["params"] == {"extra_marks": 10, "description": "a bonus!"}
 
 
 class TestGetFilesFromRepo(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'content'
-    url = 'assignments/1/groups/1/submission_files'
+    request_verb = "get"
+    response_format = "content"
+    url = "assignments/1/groups/1/submission_files"
 
     @staticmethod
     @pytest.fixture
@@ -531,91 +527,91 @@ class TestGetFilesFromRepo(AbstractTestClass):
 
     def test_called_with_basic_params(self, api, response_mock):
         api.get_files_from_repo(1, 1)
-        assert response_mock.call_args.kwargs['params'] == {"collected": True}
+        assert response_mock.call_args.kwargs["params"] == {"collected": True}
 
     def test_called_with_collected(self, api, response_mock):
         api.get_files_from_repo(1, 1, collected=False)
-        assert response_mock.call_args.kwargs['params'] == {}
+        assert response_mock.call_args.kwargs["params"] == {}
 
     def test_called_with_filename(self, api, response_mock):
-        api.get_files_from_repo(1, 1, filename='test.txt')
-        assert response_mock.call_args.kwargs['params'] == {"collected": True, "filename": 'test.txt'}
+        api.get_files_from_repo(1, 1, filename="test.txt")
+        assert response_mock.call_args.kwargs["params"] == {"collected": True, "filename": "test.txt"}
 
 
 class TestUploadFolderToRepo(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/submission_files/create_folders'
+    request_verb = "post"
+    response_format = "json"
+    url = "assignments/1/groups/1/submission_files/create_folders"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.upload_folder_to_repo(1, 1, 'subdir')
+        yield api.upload_folder_to_repo(1, 1, "subdir")
 
     def test_called_with_basic_params(self, api, response_mock):
-        api.upload_folder_to_repo(1, 1, 'subdir')
-        assert response_mock.call_args.kwargs['params'] == {"folder_path": 'subdir'}
+        api.upload_folder_to_repo(1, 1, "subdir")
+        assert response_mock.call_args.kwargs["params"] == {"folder_path": "subdir"}
 
 
 class TestUploadFileToRepo(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/submission_files'
+    request_verb = "post"
+    response_format = "json"
+    url = "assignments/1/groups/1/submission_files"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.upload_file_to_repo(1, 1, 'test.txt', 'some content')
+        yield api.upload_file_to_repo(1, 1, "test.txt", "some content")
 
     def test_discovers_mime_type(self, api, response_mock):
-        api.upload_file_to_repo(1, 1, 'test.txt', 'some content')
-        assert response_mock.call_args.kwargs['params']["mime_type"] == 'text/plain'
+        api.upload_file_to_repo(1, 1, "test.txt", "some content")
+        assert response_mock.call_args.kwargs["params"]["mime_type"] == "text/plain"
 
     def test_called_with_mime_type(self, api, response_mock):
-        api.upload_file_to_repo(1, 1, 'test.txt', 'feedback info', mime_type='application/octet-stream')
-        params = {"filename": 'test.txt', "mime_type": 'application/octet-stream'}
-        assert response_mock.call_args.kwargs['params'] == params
+        api.upload_file_to_repo(1, 1, "test.txt", "feedback info", mime_type="application/octet-stream")
+        params = {"filename": "test.txt", "mime_type": "application/octet-stream"}
+        assert response_mock.call_args.kwargs["params"] == params
 
     def test_sends_file_data(self, api, response_mock):
-        api.upload_file_to_repo(1, 1, 'test.txt', 'some content')
-        files = {"file_content": ('test.txt', 'some content')}
-        assert response_mock.call_args.kwargs['files'] == files
+        api.upload_file_to_repo(1, 1, "test.txt", "some content")
+        files = {"file_content": ("test.txt", "some content")}
+        assert response_mock.call_args.kwargs["files"] == files
 
 
 class TestRemoveFileFromRepo(AbstractTestClass):
-    request_verb = 'delete'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/submission_files/remove_file'
+    request_verb = "delete"
+    response_format = "json"
+    url = "assignments/1/groups/1/submission_files/remove_file"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.remove_file_from_repo(1, 1, 'test.txt')
+        yield api.remove_file_from_repo(1, 1, "test.txt")
 
     def test_called_with_basic_params(self, api, response_mock):
-        api.remove_file_from_repo(1, 1, 'test.txt')
-        assert response_mock.call_args.kwargs['params'] == {"filename": 'test.txt'}
+        api.remove_file_from_repo(1, 1, "test.txt")
+        assert response_mock.call_args.kwargs["params"] == {"filename": "test.txt"}
 
 
 class TestRemoveFolderFromRepo(AbstractTestClass):
-    request_verb = 'delete'
-    response_format = 'json'
-    url = 'assignments/1/groups/1/submission_files/remove_folder'
+    request_verb = "delete"
+    response_format = "json"
+    url = "assignments/1/groups/1/submission_files/remove_folder"
 
     @staticmethod
     @pytest.fixture
     def basic_call(api):
-        yield api.remove_folder_from_repo(1, 1, 'subdir')
+        yield api.remove_folder_from_repo(1, 1, "subdir")
 
     def test_called_with_basic_params(self, api, response_mock):
-        api.remove_folder_from_repo(1, 1, 'subdir')
-        assert response_mock.call_args.kwargs['params'] == {"folder_path": 'subdir'}
+        api.remove_folder_from_repo(1, 1, "subdir")
+        assert response_mock.call_args.kwargs["params"] == {"folder_path": "subdir"}
 
 
 class TestGetTestSpecs(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'json'
-    url = 'assignments/1/test_specs'
+    request_verb = "get"
+    response_format = "json"
+    url = "assignments/1/test_specs"
 
     @staticmethod
     @pytest.fixture
@@ -624,9 +620,9 @@ class TestGetTestSpecs(AbstractTestClass):
 
 
 class TestUpdateTestSpecs(AbstractTestClass):
-    request_verb = 'post'
-    response_format = 'json'
-    url = 'assignments/1/update_test_specs'
+    request_verb = "post"
+    response_format = "json"
+    url = "assignments/1/update_test_specs"
 
     @staticmethod
     @pytest.fixture
@@ -634,15 +630,15 @@ class TestUpdateTestSpecs(AbstractTestClass):
         yield api.update_test_specs(1, {})
 
     def test_called_with_basic_params(self, api, response_mock):
-        specs = {'some': ['fake', 'data']}
+        specs = {"some": ["fake", "data"]}
         api.update_test_specs(1, specs)
-        assert response_mock.call_args.kwargs['json'] == {"specs": specs}
+        assert response_mock.call_args.kwargs["json"] == {"specs": specs}
 
 
 class TestGetTestFiles(AbstractTestClass):
-    request_verb = 'get'
-    response_format = 'content'
-    url = 'assignments/1/test_files'
+    request_verb = "get"
+    response_format = "content"
+    url = "assignments/1/test_files"
 
     @staticmethod
     @pytest.fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as fh:
 
 setuptools.setup(
     name="markusapi",
-    version="0.1.0",
+    version="0.2.0",
     author="Alessio Di Sandro, Misha Schwartz",
     author_email="mschwa@cs.toronto.edu",
     description="Interface to interact with MarkUs API",
@@ -13,6 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/MarkUsProject/markus-api",
     packages=setuptools.find_packages(),
+    install_requires=["requests==2.24.0"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setuptools.setup(
     url="https://github.com/MarkUsProject/markus-api",
     packages=setuptools.find_packages(),
     install_requires=["requests==2.24.0"],
+    tests_require=["pytest==5.3.1"],
+    setup_requires=["pytest-runner"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
- use the `requests` library as a dependency to simplify the code
- http errors are now properly handled and returned (instead of causing a subsequent json parsing error)
- file uploads can actually send binary data now (bug in python's http library makes it weird/difficult to send binary data but requests handles it nicely)
- other than that there should be no changes to functionality
- rewrote tests for all methods to handle new setup